### PR TITLE
Deal with row deletion better

### DIFF
--- a/target_bigquery/__init__.py
+++ b/target_bigquery/__init__.py
@@ -221,8 +221,13 @@ def persist_lines(config, lines) -> None:
 
             key_properties[stream] = o['key_properties']
 
-            if config.get('add_metadata_columns') or hard_delete_mapping.get(stream, default_hard_delete):
-                stream_to_sync[stream] = DbSync(config, add_metadata_columns_to_schema(o))
+            hard_delete = hard_delete_mapping.get(stream, default_hard_delete)
+            if config.get('add_metadata_columns') or hard_delete:
+                stream_to_sync[stream] = DbSync(
+                    config,
+                    add_metadata_columns_to_schema(o),
+                    hard_delete=hard_delete
+                )
             else:
                 stream_to_sync[stream] = DbSync(config, o)
 

--- a/target_bigquery/__init__.py
+++ b/target_bigquery/__init__.py
@@ -377,10 +377,6 @@ def load_stream_batch(stream, records_to_load, row_count, db_sync, delete_rows=F
     if row_count[stream] > 0:
         flush_records(stream, records_to_load, row_count[stream], db_sync)
 
-        # Delete soft-deleted, flagged rows - where _sdc_deleted at is not null
-        if delete_rows:
-            db_sync.delete_rows(stream)
-
 
 def flush_records(stream, records_to_load, row_count, db_sync):
     # Seek to the beginning of the file and load

--- a/target_bigquery/__init__.py
+++ b/target_bigquery/__init__.py
@@ -294,8 +294,6 @@ def flush_streams(
     """
     parallelism = config.get("parallelism", DEFAULT_PARALLELISM)
     max_parallelism = config.get("max_parallelism", DEFAULT_MAX_PARALLELISM)
-    default_hard_delete = config.get("hard_delete", DEFAULT_HARD_DELETE)
-    hard_delete_mapping = config.get("hard_delete_mapping", {})
 
     # Parallelism 0 means auto parallelism:
     #
@@ -328,9 +326,6 @@ def flush_streams(
                             'records_to_load': streams[stream],
                             'row_count': row_count,
                             'db_sync': stream_to_sync[stream],
-                            'delete_rows': hard_delete_mapping.get(
-                                stream, default_hard_delete
-                            ),
                         },
                     )
                 )
@@ -344,7 +339,6 @@ def flush_streams(
             records_to_load=streams[streams_to_flush[0]],
             row_count=row_count,
             db_sync=stream_to_sync[streams_to_flush[0]],
-            delete_rows=hard_delete_mapping.get(streams_to_flush[0], default_hard_delete),
         )
 
     # reset flushed stream records to empty to avoid flushing same records
@@ -372,7 +366,7 @@ def flush_streams(
     return flushed_state, flushed_timestamps
 
 
-def load_stream_batch(stream, records_to_load, row_count, db_sync, delete_rows=False):
+def load_stream_batch(stream, records_to_load, row_count, db_sync):
     # Load into bigquery
     if row_count[stream] > 0:
         flush_records(stream, records_to_load, row_count[stream], db_sync)

--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -600,12 +600,6 @@ class DbSync:
         elif isinstance(grantees, str):
             grant_method(schema, grantees)
 
-    def delete_rows(self, stream):
-        table = self.table_ref(stream)
-        query = f"DELETE FROM `{table.dataset_id}.{table.table_id}` WHERE _sdc_deleted_at IS NOT NULL"
-        logger.info("Deleting rows from '{}' table... {}".format(table.table_id, query))
-        logger.info("DELETE {}".format(self.query(query).result().total_rows))
-
     def create_schema_if_not_exists(self):
         schema_name = self.schema_name
         temp_schema = self.connection_config.get('temp_schema', self.schema_name)


### PR DESCRIPTION
## Problem

* Rows that are deleted by the source should not have all data nulled out.
* Hard deletion is inefficient as it runs a separate query rather than being included in the MERGE

## Proposed changes

Add additional clauses to the MERGE.

## Types of changes

What types of changes does your code introduce to target-bigquery?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
